### PR TITLE
Fixed BoundMethod Error

### DIFF
--- a/src/Console/GroupsList.php
+++ b/src/Console/GroupsList.php
@@ -14,7 +14,12 @@
         public function __construct() {
             parent::__construct();
         }
-
+           
+        public function handle()
+        {
+                return $this->fire();
+        } 
+        
         public function fire() {
 
             $allow   = config('laravel-route-blocker.whitelist');


### PR DESCRIPTION
php artisan route:blocks:groups

In BoundMethod.php line 135:
                                                                                   
  Method Skydiver\LaravelRouteBlocker\Console\GroupsList::handle() does not exist