### PR TITLE
Use the PSR-2 coding standard just like Laravel.

### DIFF
--- a/src/Console/GroupsList.php
+++ b/src/Console/GroupsList.php
@@ -4,23 +4,27 @@ namespace Skydiver\LaravelRouteBlocker\Console;
 
 use Illuminate\Console\Command;
 
-class GroupsList extends Command {
+class GroupsList extends Command
+{
 
     protected $name        = 'route:blocks:groups';
     protected $description = 'Lists routes blocks groups.';
 
     protected $table;
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
     }
 
-    public function handle() {
+    public function handle()
+    {
         // Laravel 5.5 and superior
         $this->fire();
     }
 
-    public function fire() {
+    public function fire()
+    {
 
         $allow   = config('laravel-route-blocker.whitelist');
         $headers = ['Group', 'IP'];
@@ -38,7 +42,4 @@ class GroupsList extends Command {
 
         $this->table($headers, $list);
     }
-
 }
-
-?>

--- a/src/LaravelRouteBlockerServiceProvider.php
+++ b/src/LaravelRouteBlockerServiceProvider.php
@@ -5,41 +5,36 @@ namespace Skydiver\LaravelRouteBlocker;
 use Illuminate\Support\ServiceProvider;
 use Skydiver\LaravelRouteBlocker\Console\GroupsList as GroupsList;
 
-class LaravelRouteBlockerServiceProvider extends ServiceProvider {
+class LaravelRouteBlockerServiceProvider extends ServiceProvider
+{
 
-    public function register() {
-
+    public function register()
+    {
+        //
     }
 
-    public function boot() {
-
+    public function boot()
+    {
+        $path = __DIR__.'/config/config.php';
         // PUBLISH CONFIG
-        $this->publishes([__DIR__.'/config/config.php' => config_path('laravel-route-blocker.php')], 'LaravelRouteBlocker');
+        $this->publishes([$path => config_path('laravel-route-blocker.php')], 'LaravelRouteBlocker');
 
         // MERGE APP + PACKAGE CONFIG
-        $this->mergeConfigFrom(__DIR__.'/config/config.php', 'laravel-route-blocker');
+        $this->mergeConfigFrom($path, 'laravel-route-blocker');
 
         // REGISTER ARTISAN COMMANDS
         if (version_compare($this->app->version(), '5.4', '>=')) {
-
             // Laravel 5.4 and superior
             $this->app->singleton('route_blocker.groups_list.command', function ($app) {
                 return new GroupsList;
             });
-
         } else {
-
             // Laravel 5.1, 5.2, 5.3
             $this->app['route_blocker.groups_list.command'] = $this->app->share(function ($app) {
                 return new GroupsList;
             });
-
         }
 
         $this->commands('route_blocker.groups_list.command');
-
     }
-
 }
-
-?>

--- a/src/Middleware/WhitelistMiddleware.php
+++ b/src/Middleware/WhitelistMiddleware.php
@@ -5,15 +5,18 @@ namespace Skydiver\LaravelRouteBlocker\Middleware;
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
 
-class WhitelistMiddleware {
+class WhitelistMiddleware
+{
 
     protected $auth;
 
-    public function __construct(Guard $auth) {
+    public function __construct(Guard $auth)
+    {
         $this->auth = $auth;
     }
 
-    public function handle($request, Closure $next, $group) {
+    public function handle($request, Closure $next, $group)
+    {
 
         $allow = config('laravel-route-blocker.whitelist.' . $group);
         $ip    = $request->getClientIp();
@@ -28,14 +31,11 @@ class WhitelistMiddleware {
         }
 
         // REDIRECT OR THROW ERROR
-        if (config('laravel-route-blocker.redirect_to') && filter_var(config('laravel-route-blocker.redirect_to'), FILTER_VALIDATE_URL)) {
+        if (config('laravel-route-blocker.redirect_to')
+            && filter_var(config('laravel-route-blocker.redirect_to'), FILTER_VALIDATE_URL)) {
             return redirect()->to(config('laravel-route-blocker.redirect_to'));
         } else {
             abort(config('laravel-route-blocker.response_status'), config('laravel-route-blocker.response_message'));
         }
-
     }
-
 }
-
-?>

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -26,5 +26,3 @@
         'response_message' => ''    // MESSAGE (COMBINED WITH STATUS CODE)
 
     ];
-
-?>


### PR DESCRIPTION
This PR applies PSR-2 coding style, just like Laravel (https://laravel.com/docs/5.6/contributions#coding-style)

The PR started to remove the PHP closing tags. Since it's recommend to omit the PHP closing tag for PHP-only files to prevent issues.

This is defined in the [PSR-2](https://www.php-fig.org/psr/psr-2/) as well:

`The closing ?> tag MUST be omitted from files containing only PHP.`